### PR TITLE
Update stat div for new activity overview for profile page

### DIFF
--- a/src/streak.js
+++ b/src/streak.js
@@ -85,7 +85,7 @@ if (document.body.classList.contains('page-profile')) {
       return;
     }
 
-    const contribContainer = document.querySelector('.js-contribution-graph > .border');
+    const contribContainer = document.querySelector('.js-yearly-contributions');
 
     const contribs    = contribGraph.querySelectorAll('rect.day');
     const contribsLen = contribs.length - 1;
@@ -158,25 +158,37 @@ if (document.body.classList.contains('page-profile')) {
     // =======================================================================
 
     // Remove existing stats, if present
-    const existingStats = Array.from(contribContainer.getElementsByClassName('gh-streak-box'));
-    for (let i = 0; i < existingStats.length; i++) {
-      contribContainer.removeChild(existingStats[i]);
+    var statWrapperDiv = document.getElementById('gh-streak-wrapper');
+    if (statWrapperDiv) {
+      contribContainer.removeChild(statWrapperDiv);
     }
 
+    // Create wrapper for all stats
+    statWrapperDiv = document.createElement('div');
+    statWrapperDiv.className = 'position-relative';
+    statWrapperDiv.id = "gh-streak-wrapper";
+
+    var statWrapperDivBorderBox = document.createElement('div');
+    statWrapperDivBorderBox.className = 'border border-gray-dark border-top-0';
+
     // Create/add stats to page
-    contribContainer.appendChild(
+    statWrapperDivBorderBox.appendChild(
       createStatDiv('Total contributions', 'total', totalContribs));
 
-    contribContainer.appendChild(
+    statWrapperDivBorderBox.appendChild(
       createStatDiv('Longest streak', 'days', longestStreak));
 
-    contribContainer.appendChild(
+    statWrapperDivBorderBox.appendChild(
       createStatDiv('Current streak', 'days', currentStreak));
 
-    // Remove number from title
-    const elTitle = document.querySelector('.js-contribution-graph > h2.f4');
-    if (elTitle) {
-      elTitle.innerText = elTitle.innerText.replace(/^\d*,?\.?\d* contributions/, 'Contributions');
+    statWrapperDiv.appendChild(statWrapperDivBorderBox);
+
+    // Search for Sibling Activity Div and if present add before Sibling Div
+    const statWrapperSiblingDiv = document.getElementById('user-activity-overview');
+    if (statWrapperSiblingDiv) {
+      contribContainer.insertBefore(statWrapperDiv, statWrapperSiblingDiv);
+    } else {
+      contribContainer.appendChild(statWrapperDiv);
     }
   };
 


### PR DESCRIPTION
Update for [Activity Overview](https://blog.github.com/changelog/2018-08-24-profile-activity-overview/)

### With Activity Overview 
<img width="618" alt="screen shot 2018-10-11 at 11 47 12 am" src="https://user-images.githubusercontent.com/10768588/46826677-755bec80-cd4b-11e8-88f3-febc8e3e9846.png">

### Without Activity Overview
<img width="738" alt="screen shot 2018-10-11 at 11 48 05 am" src="https://user-images.githubusercontent.com/10768588/46826732-98869c00-cd4b-11e8-8dba-42aa00889262.png">
